### PR TITLE
feat: extend types and install reveal.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "openai": "^6.19.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
-        "react-markdown": "^10.1.0"
+        "react-markdown": "^10.1.0",
+        "reveal.js": "^5.2.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -7568,6 +7569,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reveal.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-5.2.1.tgz",
+      "integrity": "sha512-r7//6mIM5p34hFiDMvYfXgyjXqGRta+/psd9YtytsgRlrpRzFv4RbH76TXd2qD+7ZPZEbpBDhdRhJaFgfQ7zNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
@@ -8720,6 +8730,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "openai": "^6.19.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "reveal.js": "^5.2.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/lib/reveal-themes.ts
+++ b/src/lib/reveal-themes.ts
@@ -1,0 +1,26 @@
+export interface RevealTheme {
+  id: string;
+  name: string;
+  previewBackground: string;
+  previewTextColor: string;
+}
+
+export const REVEAL_THEMES: RevealTheme[] = [
+  { id: "black", name: "Black", previewBackground: "#191919", previewTextColor: "#ffffff" },
+  { id: "white", name: "White", previewBackground: "#ffffff", previewTextColor: "#222222" },
+  { id: "league", name: "League", previewBackground: "#2b2b2b", previewTextColor: "#eee8d5" },
+  { id: "sky", name: "Sky", previewBackground: "#f7fbfc", previewTextColor: "#333333" },
+  { id: "beige", name: "Beige", previewBackground: "#f7f3de", previewTextColor: "#333333" },
+  { id: "simple", name: "Simple", previewBackground: "#ffffff", previewTextColor: "#000000" },
+  { id: "serif", name: "Serif", previewBackground: "#f0edde", previewTextColor: "#000000" },
+  { id: "blood", name: "Blood", previewBackground: "#222222", previewTextColor: "#eee8d5" },
+  { id: "night", name: "Night", previewBackground: "#111111", previewTextColor: "#eee8d5" },
+  { id: "moon", name: "Moon", previewBackground: "#002b36", previewTextColor: "#93a1a1" },
+  { id: "solarized", name: "Solarized", previewBackground: "#fdf6e3", previewTextColor: "#657b83" },
+];
+
+const VALID_THEME_IDS = new Set(REVEAL_THEMES.map((t) => t.id));
+
+export function isValidTheme(themeId: string): boolean {
+  return VALID_THEME_IDS.has(themeId);
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,8 +1,21 @@
+export type SlideTransition =
+  | "none"
+  | "fade"
+  | "slide"
+  | "convex"
+  | "concave"
+  | "zoom";
+
+export type SlideLayout = "default" | "center" | "two-column";
+
 export interface Slide {
   title: string;
   content: string;
   notes?: string;
   backgroundImage?: string;
+  transition?: SlideTransition;
+  backgroundColor?: string;
+  layout?: SlideLayout;
 }
 
 export interface Presentation {
@@ -11,4 +24,6 @@ export interface Presentation {
   createdAt: string;
   updatedAt: string;
   slides: Slide[];
+  theme?: string;
+  transition?: SlideTransition;
 }


### PR DESCRIPTION
Closes #13
Closes #14

## Changes
- Extended Slide type with transition, backgroundColor, layout fields
- Extended Presentation type with theme, transition fields
- Added SlideTransition and SlideLayout type aliases
- Created reveal-themes.ts with metadata for all 11 built-in reveal.js themes
- Added isValidTheme() helper for theme validation
- Installed reveal.js 5.2.1
- All new fields are optional — backwards compatible
- Build and all 23 tests pass