### PR TITLE
feat: upgrade editor, chat, and nav for reveal.js

### DIFF
--- a/src/app/components/SlideEditor.tsx
+++ b/src/app/components/SlideEditor.tsx
@@ -1,14 +1,29 @@
 "use client";
 
 import { useState } from "react";
-import { Slide } from "@/lib/types";
+import { Slide, SlideTransition, SlideLayout } from "@/lib/types";
 import SlideViewer from "./SlideViewer";
+
+const TRANSITIONS: SlideTransition[] = ["none", "fade", "slide", "convex", "concave", "zoom"];
+const LAYOUTS: SlideLayout[] = ["default", "center", "two-column"];
 
 interface SlideEditorProps {
   slide: Slide;
   slideIndex: number;
   onSave: (updated: Slide) => void;
   onCancel: () => void;
+}
+
+/** Wrap markdown list items with fragment class for reveal.js step-through */
+function applyFragments(text: string): string {
+  return text.replace(/^(\s*[-*]\s+)/gm, '$1<span class="fragment">') 
+    .replace(/^(<span class="fragment">)(.+)$/gm, '$1$2</span>');
+}
+
+function removeFragments(text: string): string {
+  return text
+    .replace(/<span class="fragment">/g, "")
+    .replace(/<\/span>$/gm, "");
 }
 
 export default function SlideEditor({
@@ -19,8 +34,49 @@ export default function SlideEditor({
 }: SlideEditorProps) {
   const [title, setTitle] = useState(slide.title);
   const [content, setContent] = useState(slide.content);
+  const [transition, setTransition] = useState<SlideTransition>(slide.transition ?? "slide");
+  const [backgroundColor, setBackgroundColor] = useState(slide.backgroundColor ?? "");
+  const [backgroundImage, setBackgroundImage] = useState(slide.backgroundImage ?? "");
+  const [layout, setLayout] = useState<SlideLayout>(slide.layout ?? "default");
+  const [editMode, setEditMode] = useState<"markdown" | "html">("markdown");
+  const [useFragments, setUseFragments] = useState(
+    slide.content.includes('class="fragment"')
+  );
 
-  const previewSlide: Slide = { ...slide, title, content };
+  const previewSlide: Slide = {
+    ...slide,
+    title,
+    content: useFragments ? applyFragments(content) : content,
+    transition,
+    backgroundColor: backgroundColor || undefined,
+    backgroundImage: backgroundImage || undefined,
+    layout,
+  };
+
+  const handleSave = () => {
+    const finalContent = useFragments ? applyFragments(content) : content;
+    onSave({
+      ...slide,
+      title,
+      content: finalContent,
+      transition,
+      backgroundColor: backgroundColor || undefined,
+      backgroundImage: backgroundImage || undefined,
+      layout,
+    });
+  };
+
+  const handleFragmentToggle = (checked: boolean) => {
+    setUseFragments(checked);
+    if (!checked) {
+      setContent(removeFragments(content));
+    }
+  };
+
+  const inputClasses =
+    "rounded-lg border border-white/20 bg-white/5 px-4 py-2.5 text-white placeholder-white/30 outline-none focus:border-indigo-500";
+  const selectClasses =
+    "rounded-lg border border-white/20 bg-white/5 px-4 py-2.5 text-white outline-none focus:border-indigo-500";
 
   return (
     <div className="flex h-full w-full flex-col lg:flex-row">
@@ -34,27 +90,115 @@ export default function SlideEditor({
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            className="rounded-lg border border-white/20 bg-white/5 px-4 py-2.5 text-white placeholder-white/30 outline-none focus:border-indigo-500"
+            className={inputClasses}
             placeholder="Slide title"
           />
         </label>
 
-        <label className="flex flex-1 flex-col gap-1.5">
-          <span className="text-sm font-medium text-white/70">
-            Content (Markdown)
-          </span>
+        {/* Reveal.js slide options */}
+        <div className="grid grid-cols-2 gap-3">
+          <label className="flex flex-col gap-1.5">
+            <span className="text-sm font-medium text-white/70">Transition</span>
+            <select
+              value={transition}
+              onChange={(e) => setTransition(e.target.value as SlideTransition)}
+              className={selectClasses}
+            >
+              {TRANSITIONS.map((t) => (
+                <option key={t} value={t}>
+                  {t.charAt(0).toUpperCase() + t.slice(1)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1.5">
+            <span className="text-sm font-medium text-white/70">Layout</span>
+            <select
+              value={layout}
+              onChange={(e) => setLayout(e.target.value as SlideLayout)}
+              className={selectClasses}
+            >
+              {LAYOUTS.map((l) => (
+                <option key={l} value={l}>
+                  {l === "two-column" ? "Two Column" : l.charAt(0).toUpperCase() + l.slice(1)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1.5">
+            <span className="text-sm font-medium text-white/70">Background Color</span>
+            <div className="flex gap-2">
+              <input
+                type="color"
+                value={backgroundColor || "#000000"}
+                onChange={(e) => setBackgroundColor(e.target.value)}
+                className="h-10 w-10 cursor-pointer rounded border border-white/20 bg-transparent"
+              />
+              <input
+                type="text"
+                value={backgroundColor}
+                onChange={(e) => setBackgroundColor(e.target.value)}
+                className={`flex-1 ${inputClasses}`}
+                placeholder="#000000"
+              />
+            </div>
+          </label>
+
+          <label className="flex flex-col gap-1.5">
+            <span className="text-sm font-medium text-white/70">Background Image URL</span>
+            <input
+              type="text"
+              value={backgroundImage}
+              onChange={(e) => setBackgroundImage(e.target.value)}
+              className={inputClasses}
+              placeholder="https://example.com/image.jpg"
+            />
+          </label>
+        </div>
+
+        {/* Content editing */}
+        <div className="flex flex-1 flex-col gap-1.5">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-white/70">
+              Content ({editMode === "markdown" ? "Markdown" : "HTML"})
+            </span>
+            <div className="flex items-center gap-3">
+              <label className="flex items-center gap-1.5 text-xs text-white/50">
+                <input
+                  type="checkbox"
+                  checked={useFragments}
+                  onChange={(e) => handleFragmentToggle(e.target.checked)}
+                  className="accent-indigo-500"
+                />
+                Fragments
+              </label>
+              <button
+                type="button"
+                onClick={() => setEditMode(editMode === "markdown" ? "html" : "markdown")}
+                className="rounded bg-white/10 px-2 py-1 text-xs text-white/60 transition-colors hover:bg-white/20 hover:text-white"
+              >
+                {editMode === "markdown" ? "Switch to HTML" : "Switch to Markdown"}
+              </button>
+            </div>
+          </div>
           <textarea
             value={content}
             onChange={(e) => setContent(e.target.value)}
-            className="flex-1 resize-none rounded-lg border border-white/20 bg-white/5 px-4 py-2.5 font-mono text-sm text-white placeholder-white/30 outline-none focus:border-indigo-500"
-            placeholder="Slide content in markdown…"
+            className={`flex-1 resize-none font-mono text-sm ${inputClasses}`}
+            placeholder={
+              editMode === "markdown"
+                ? "Slide content in markdown…"
+                : "<p>Slide content in HTML…</p>"
+            }
             rows={10}
           />
-        </label>
+        </div>
 
         <div className="flex gap-3">
           <button
-            onClick={() => onSave({ ...slide, title, content })}
+            onClick={handleSave}
             className="rounded-lg bg-indigo-600 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-500"
           >
             Save

--- a/src/app/components/SlideNav.tsx
+++ b/src/app/components/SlideNav.tsx
@@ -9,6 +9,10 @@ interface SlideNavProps {
   onNext: () => void;
   onAddSlide?: () => void;
   onAddBlank?: () => void;
+  onSpeakerNotes?: () => void;
+  onFullscreen?: () => void;
+  onOverview?: () => void;
+  onPdfExport?: () => void;
 }
 
 export default function SlideNav({
@@ -18,6 +22,10 @@ export default function SlideNav({
   onNext,
   onAddSlide,
   onAddBlank,
+  onSpeakerNotes,
+  onFullscreen,
+  onOverview,
+  onPdfExport,
 }: SlideNavProps) {
   const isFirst = currentIndex === 0;
   const isLast = currentIndex === totalSlides - 1;
@@ -38,25 +46,72 @@ export default function SlideNav({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [handleKeyDown]);
 
+  const btnBase =
+    "rounded-lg bg-white/10 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-white/20";
+
   return (
     <nav className="flex w-full items-center justify-between bg-black/60 px-6 py-4 backdrop-blur-sm">
       <button
         onClick={onPrevious}
         disabled={isFirst}
         aria-label="Previous slide"
+        title="Previous slide (←)"
         className="rounded-lg bg-white/10 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-40"
       >
         ← Previous
       </button>
 
-      <span className="text-sm font-medium text-white/80">
-        {currentIndex + 1} / {totalSlides}
-      </span>
+      <div className="flex items-center gap-2">
+        {onSpeakerNotes && (
+          <button
+            onClick={onSpeakerNotes}
+            className={btnBase}
+            title="Speaker notes (S)"
+            aria-label="Speaker notes"
+          >
+            🗒
+          </button>
+        )}
+        {onFullscreen && (
+          <button
+            onClick={onFullscreen}
+            className={btnBase}
+            title="Toggle fullscreen (F)"
+            aria-label="Toggle fullscreen"
+          >
+            ⛶
+          </button>
+        )}
+        {onOverview && (
+          <button
+            onClick={onOverview}
+            className={btnBase}
+            title="Slide overview (O)"
+            aria-label="Slide overview"
+          >
+            ▦
+          </button>
+        )}
+        {onPdfExport && (
+          <button
+            onClick={onPdfExport}
+            className={btnBase}
+            title="Export to PDF (print-pdf)"
+            aria-label="Export to PDF"
+          >
+            📄
+          </button>
+        )}
+        <span className="px-2 text-sm font-medium text-white/80">
+          {currentIndex + 1} / {totalSlides}
+        </span>
+      </div>
 
       <div className="flex items-center gap-2">
         {onAddSlide && (
           <button
             onClick={onAddSlide}
+            title="Add AI-generated slide"
             className="rounded-lg bg-indigo-600/80 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-500"
           >
             + AI Slide
@@ -65,6 +120,7 @@ export default function SlideNav({
         {onAddBlank && (
           <button
             onClick={onAddBlank}
+            title="Add blank slide"
             className="rounded-lg bg-white/10 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-white/20"
           >
             + Blank
@@ -74,6 +130,7 @@ export default function SlideNav({
           onClick={onNext}
           disabled={isLast}
           aria-label="Next slide"
+          title="Next slide (→)"
           className="rounded-lg bg-white/10 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-40"
         >
           Next →

--- a/src/app/presentation/[slug]/page.tsx
+++ b/src/app/presentation/[slug]/page.tsx
@@ -179,6 +179,21 @@ export default function PresentationPage() {
     }
   }, []);
 
+  const handleSpeakerNotes = useCallback(() => {
+    // Open speaker notes view by dispatching 's' key to reveal.js
+    const revealEl = document.querySelector(".reveal") as HTMLElement | null;
+    if (revealEl) {
+      revealEl.focus();
+      revealEl.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "s", bubbles: true })
+      );
+    }
+  }, []);
+
+  const handlePdfExport = useCallback(() => {
+    window.open(`${window.location.pathname}?print-pdf`, "_blank");
+  }, []);
+
   const handleSaveSlide = (updated: Slide) => {
     if (!presentation) return;
     const newSlides = [...presentation.slides];
@@ -231,6 +246,7 @@ export default function PresentationPage() {
           <PresentationChat
             existingSlides={[]}
             onSlidesGenerated={handleSlidesGenerated}
+            onThemeChange={handleThemeChange}
           />
         </div>
       </div>
@@ -279,6 +295,7 @@ export default function PresentationPage() {
               existingSlides={[]}
               onSlidesGenerated={handleSlidesGenerated}
               presentationTitle={presentation.title}
+              onThemeChange={handleThemeChange}
             />
           </div>
         )}
@@ -403,6 +420,10 @@ export default function PresentationPage() {
           onNext={() => revealRef.current?.next()}
           onAddSlide={handleAddSlide}
           onAddBlank={handleAddBlank}
+          onSpeakerNotes={handleSpeakerNotes}
+          onFullscreen={handleFullscreen}
+          onOverview={() => revealRef.current?.toggleOverview()}
+          onPdfExport={handlePdfExport}
         />
       </div>
 
@@ -413,6 +434,7 @@ export default function PresentationPage() {
             existingSlides={slides}
             onSlidesGenerated={handleSlidesGenerated}
             presentationTitle={presentation.title}
+            onThemeChange={handleThemeChange}
           />
         </div>
       )}


### PR DESCRIPTION
Closes #18
Closes #20
Closes #21

## Changes
### SlideEditor (#18)
- Added transition picker, background color/image, layout selector
- Added markdown/HTML toggle and fragment support

### PresentationChat (#20)
- Theme change commands detected in chat
- Style context passed to AI API
- Suggested theme one-click apply

### SlideNav (#21)
- Speaker notes, fullscreen, overview, PDF export buttons
- Keyboard shortcut tooltips
- reveal.js keyboard coordination