### PR TITLE
fix: Architecture review — style mismatch & reveal.js init error handling

### DIFF
--- a/src/app/components/PresentationChat.tsx
+++ b/src/app/components/PresentationChat.tsx
@@ -43,7 +43,7 @@ function detectCodeRequest(text: string): boolean {
 function inferStyle(text: string): string | undefined {
   if (detectCodeRequest(text)) return "technical";
   if (/technical|code|programming|developer/i.test(text)) return "technical";
-  if (/business|corporate|executive/i.test(text)) return "business";
+  if (/business|corporate|executive/i.test(text)) return "professional";
   if (/creative|design|artistic/i.test(text)) return "creative";
   return undefined;
 }
@@ -112,7 +112,7 @@ export default function PresentationChat({
       onSlidesGenerated(slides);
 
       // Suggest a theme based on style
-      const suggestedTheme = style === "technical" ? "moon" : style === "business" ? "simple" : undefined;
+      const suggestedTheme = style === "technical" ? "moon" : style === "professional" ? "simple" : undefined;
 
       setMessages((prev) => [
         ...prev,

--- a/src/app/components/RevealSlideshow.tsx
+++ b/src/app/components/RevealSlideshow.tsx
@@ -188,7 +188,9 @@ const RevealSlideshow = forwardRef<RevealSlideshowRef, RevealSlideshowProps>(
         setReady(true);
       }
 
-      init();
+      init().catch((err) => {
+        console.error("Failed to initialize reveal.js:", err);
+      });
 
       return () => {
         destroyed = true;


### PR DESCRIPTION
## Architecture Review (#23)

### Checklist Results

| # | Check | Status |
|---|-------|--------|
| 1 | reveal.js lifecycle (useEffect init/destroy, no memory leaks) | ✅ Pass |
| 2 | Theme switching (CSS loading/unloading) | ✅ Pass |
| 3 | Keyboard coordination (reveal.js vs editor/chat) | ✅ Pass |
| 4 | Type consistency (extended types used everywhere) | ✅ Pass |
| 5 | Error handling (reveal.js init failure) | ⚠️ Fixed — added .catch() |
| 6 | Backwards compatibility (v1 presentations) | ✅ Pass |
| 7 | Build verification (build + 50 tests pass) | ✅ Pass |
| 8 | File organization | ✅ Pass |

### Bugs Fixed

**1. Style mismatch between PresentationChat and API (bug)**
- \PresentationChat.inferStyle()\ returned \'business'\ for business/corporate/executive keywords
- The \/api/generate\ route only accepts \'professional' | 'creative' | 'minimal' | 'technical'\
- Sending \style: 'business'\ would return a 400 error to the user
- **Fix:** Changed \inferStyle()\ to return \'professional'\ instead of \'business'\, and updated the \suggestedTheme\ check to match

**2. Unhandled promise rejection on reveal.js init failure (hardening)**
- If \import('reveal.js')\ or \deck.initialize()\ threw, the error was silently swallowed
- **Fix:** Added \.catch()\ on the \init()\ call to log the error

### Architecture Notes (all clean)
- **Lifecycle:** \destroyed\ flag properly guards async init/cleanup race. Cleanup calls \off()\, \destroy()\, nulls ref.
- **Theme CSS:** Single \<link>\ element swapped by ID, cleaned up on unmount. No leaks.
- **Keyboard:** \keyboardCondition: 'focused'\ on reveal.js + SlideNav checks \evealEl.contains(e.target)\ = no conflicts.
- **Types:** \Slide\ and \Presentation\ types used consistently. All reveal.js fields optional.
- **Backwards compat:** v1 presentations (no theme/transition) render correctly — verified by tests.

Closes #23