### PR TITLE
feat: add GitHub OAuth authentication via NextAuth.js (#41)

### DIFF
--- a/.ai-team/decisions/inbox/mcmanus-github-oauth.md
+++ b/.ai-team/decisions/inbox/mcmanus-github-oauth.md
@@ -1,0 +1,58 @@
+### GitHub OAuth via NextAuth.js (Auth.js v5)
+**Author:** McManus (Backend Dev) - **Date:** 2026-02-10 - **Issue:** #41
+
+#### Auth Configuration
+
+- Auth.js v5 (`next-auth@5.0.0-beta.30`) with GitHub OAuth provider
+- Config in `src/auth.ts` exports `handlers`, `auth`, `signIn`, `signOut`
+- Route handler at `src/app/api/auth/[...nextauth]/route.ts`
+- JWT strategy - sessions in encrypted cookies, no database needed
+- Auth.js v5 auto-reads `AUTH_GITHUB_ID` and `AUTH_GITHUB_SECRET` env vars
+
+#### Session Data Shape
+
+```typescript
+session.user = {
+  id: string;        // GitHub user ID
+  name: string;      // GitHub display name
+  email: string;     // GitHub email
+  image: string;     // GitHub avatar URL
+  username: string;  // GitHub login (e.g., "spboyer")
+}
+```
+
+#### Local Dev Bypass
+
+When `AUTH_GITHUB_ID` is not set, middleware skips all auth checks.
+`UserMenu` shows "Dev Mode" badge. Detected via `data-auth-enabled` on `<html>`.
+
+#### Middleware
+
+Uses Auth.js v5 `auth()` wrapper with `req.auth`. Matcher: `/api/:path*`, `/presentation/:path*`.
+
+- **Public:** `/`, `/auth/signin`, `/api/auth/*`
+- **Protected:** `/api/presentations/*`, `/api/generate/*`, `/presentation/*`
+- API routes return 401 JSON; page routes redirect to sign-in
+
+#### Frontend
+
+- `AuthProvider.tsx` wraps `SessionProvider` from `next-auth/react`
+- `UserMenu.tsx` - avatar + sign-out / "Sign in with GitHub" / "Dev Mode"
+- Added to home page and presentation page headers
+
+#### Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `AUTH_GITHUB_ID` | No (enables OAuth) | GitHub OAuth App Client ID |
+| `AUTH_GITHUB_SECRET` | With AUTH_GITHUB_ID | OAuth App Client Secret |
+| `AUTH_SECRET` | Auto-generated in dev | Session encryption secret |
+
+#### Setup (Manual Step for Shayne)
+
+1. GitHub Settings > Developer settings > OAuth Apps > New OAuth App
+2. Application name: SlideMaker
+3. Homepage URL: `http://localhost:3000`
+4. Callback URL: `http://localhost:3000/api/auth/callback/github`
+5. Copy Client ID -> `AUTH_GITHUB_ID`, generate Client Secret -> `AUTH_GITHUB_SECRET`
+6. Add to `.env.local` (gitignored)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ AI-powered slide presentation builder. Describe a topic, get a polished reveal.j
 | Styling | [Tailwind CSS 4](https://tailwindcss.com) |
 | Slides | [reveal.js 5.x](https://revealjs.com) |
 | AI | [GitHub Models API](https://github.com/marketplace/models) via OpenAI SDK |
+| Auth | [Auth.js v5](https://authjs.dev) (NextAuth.js) — GitHub OAuth |
 | Testing | [Vitest](https://vitest.dev), [Playwright](https://playwright.dev) |
 
 ## Prerequisites
@@ -78,6 +79,19 @@ SlideМaker uses the **GitHub Models API** for AI slide generation. Authenticati
    ```
 
 > **⚠️ Security:** Never commit tokens or secrets to source control. The `.env.local` file is already in `.gitignore`.
+### GitHub OAuth (Optional)
+
+To enable GitHub OAuth sign-in, create a [GitHub OAuth App](https://github.com/settings/developers) and add these to `.env.local`:
+
+```
+AUTH_GITHUB_ID=your-client-id
+AUTH_GITHUB_SECRET=your-client-secret
+AUTH_SECRET=random-secret-string
+```
+
+Set the **Authorization callback URL** to `http://localhost:3000/api/auth/callback/github`.
+
+When `AUTH_GITHUB_ID` is not set, the app runs in **Dev Mode** — all routes are accessible without authentication.
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@azure/identity": "^4.13.0",
         "@azure/storage-blob": "^12.31.0",
         "next": "16.1.6",
+        "next-auth": "^5.0.0-beta.30",
         "openai": "^6.19.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -41,6 +42,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.0.tgz",
+      "integrity": "sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -1935,6 +1965,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@playwright/test": {
@@ -6201,6 +6240,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7504,6 +7552,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.30.tgz",
+      "integrity": "sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.0"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -7538,6 +7613,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.4.tgz",
+      "integrity": "sha512-EKlVEgav8zH31IXxvhCqjEgQws6S9QmnmJyLXmeV5REf59g7VmqRVa5l/rhGWtUqGm2rLVTNwukn9hla5kJ2WQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -7955,6 +8039,26 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@azure/identity": "^4.13.0",
     "@azure/storage-blob": "^12.31.0",
     "next": "16.1.6",
+    "next-auth": "^5.0.0-beta.30",
     "openai": "^6.19.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,2 @@
+import { handlers } from "@/auth";
+export const { GET, POST } = handlers;

--- a/src/app/components/AuthProvider.tsx
+++ b/src/app/components/AuthProvider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+
+export default function AuthProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/src/app/components/UserMenu.tsx
+++ b/src/app/components/UserMenu.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useSession, signIn, signOut } from "next-auth/react";
+
+export default function UserMenu() {
+  const authEnabled =
+    typeof window !== "undefined"
+      ? document.documentElement.dataset.authEnabled === "true"
+      : false;
+
+  const { data: session, status } = useSession();
+
+  if (!authEnabled) {
+    return (
+      <span className="rounded bg-amber-600/20 px-2 py-0.5 text-[10px] font-medium text-amber-400">
+        Dev Mode
+      </span>
+    );
+  }
+
+  if (status === "loading") {
+    return (
+      <span className="h-5 w-5 animate-pulse rounded-full bg-white/20" />
+    );
+  }
+
+  if (session?.user) {
+    return (
+      <div className="flex items-center gap-1.5">
+        {session.user.image && (
+          <img
+            src={session.user.image}
+            alt={session.user.name ?? "User"}
+            className="h-5 w-5 rounded-full"
+          />
+        )}
+        <span className="text-xs text-white/70">
+          {(session.user as { username?: string }).username ??
+            session.user.name}
+        </span>
+        <button
+          onClick={() => signOut()}
+          className="rounded bg-white/10 px-2 py-0.5 text-[10px] text-white/60 transition-colors hover:bg-white/20 hover:text-white"
+        >
+          Sign out
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={() => signIn("github")}
+      className="rounded bg-white/10 px-2 py-1 text-xs text-white transition-colors hover:bg-white/20"
+    >
+      Sign in with GitHub
+    </button>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import AuthProvider from "@/app/components/AuthProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -22,12 +23,13 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const authEnabled = !!process.env.AUTH_GITHUB_ID;
   return (
-    <html lang="en">
+    <html lang="en" data-auth-enabled={authEnabled ? "true" : "false"}>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <AuthProvider>{children}</AuthProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,17 @@
 import PresentationList from "@/app/components/PresentationList";
+import UserMenu from "@/app/components/UserMenu";
 
 export default function Home() {
   return (
     <div className="min-h-screen bg-gray-900">
-      <header className="border-b border-white/10 px-6 py-6">
-        <h1 className="text-2xl font-bold text-white">SlideMaker</h1>
-        <p className="mt-1 text-sm text-white/50">
-          AI-powered presentation builder
-        </p>
+      <header className="flex items-center justify-between border-b border-white/10 px-6 py-6">
+        <div>
+          <h1 className="text-2xl font-bold text-white">SlideMaker</h1>
+          <p className="mt-1 text-sm text-white/50">
+            AI-powered presentation builder
+          </p>
+        </div>
+        <UserMenu />
       </header>
       <main className="mx-auto max-w-5xl px-6 py-8">
         <PresentationList />

--- a/src/app/presentation/[slug]/page.tsx
+++ b/src/app/presentation/[slug]/page.tsx
@@ -12,6 +12,7 @@ import SlideEditor from "@/app/components/SlideEditor";
 import SlideManager from "@/app/components/SlideManager";
 import PresentationChat from "@/app/components/PresentationChat";
 import ThemePicker from "@/app/components/ThemePicker";
+import UserMenu from "@/app/components/UserMenu";
 
 export default function PresentationPage() {
   const params = useParams<{ slug: string }>();
@@ -367,7 +368,8 @@ export default function PresentationPage() {
             ←
           </Link>
           <span className="truncate px-2 text-xs font-medium text-white/80">{presentation.title}</span>
-          <div className="flex gap-1.5">
+          <div className="flex items-center gap-1.5">
+            <UserMenu />
             <ThemePicker
               currentTheme={presentation.theme ?? "black"}
               onThemeChange={handleThemeChange}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,33 @@
+import NextAuth from "next-auth";
+import GitHub from "next-auth/providers/github";
+import type { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      username?: string;
+    } & DefaultSession["user"];
+  }
+}
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  providers: [GitHub],
+  session: { strategy: "jwt" },
+  callbacks: {
+    async jwt({ token, profile }) {
+      if (profile) {
+        token.username = (profile as { login?: string }).login;
+        token.picture = (profile as { avatar_url?: string }).avatar_url;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.id = token.sub ?? "";
+        session.user.username = (token.username as string) ?? undefined;
+        session.user.image = (token.picture as string) ?? undefined;
+      }
+      return session;
+    },
+  },
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
+// --- CORS helpers (from #44) ---
+
 function getAllowedOrigin(requestOrigin: string | null): string | null {
   const env = process.env.NODE_ENV;
   const configuredOrigins = process.env.CORS_ALLOWED_ORIGINS;
@@ -47,23 +49,64 @@ function setCorsHeaders(
   headers.set("Access-Control-Max-Age", "86400");
 }
 
-export function middleware(request: NextRequest) {
+// --- Auth helpers ---
+
+const PUBLIC_PATHS = ["/", "/auth/signin"];
+const PROTECTED_PREFIXES = ["/api/presentations", "/api/generate", "/presentation"];
+
+function isPublicPath(pathname: string): boolean {
+  if (PUBLIC_PATHS.includes(pathname)) return true;
+  if (pathname.startsWith("/api/auth")) return true;
+  return false;
+}
+
+function isProtectedPath(pathname: string): boolean {
+  return PROTECTED_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
+// --- Combined middleware: CORS first, then auth ---
+
+export async function middleware(request: NextRequest) {
   const origin = request.headers.get("origin");
   const allowedOrigin = getAllowedOrigin(origin);
 
-  // Handle preflight OPTIONS requests
+  // 1. Handle preflight OPTIONS requests — return 204 with CORS headers
   if (request.method === "OPTIONS") {
     const response = new NextResponse(null, { status: 204 });
     setCorsHeaders(response.headers, allowedOrigin);
     return response;
   }
 
-  // Add CORS headers to the response
+  // 2. Check if auth is enabled (AUTH_GITHUB_ID exists)
+  const authEnabled = !!process.env.AUTH_GITHUB_ID;
+  const { pathname } = request.nextUrl;
+
+  if (authEnabled && !isPublicPath(pathname) && isProtectedPath(pathname)) {
+    // Dynamically import auth to avoid build errors when next-auth is not configured
+    const { auth } = await import("@/auth");
+    const session = await auth();
+
+    if (!session) {
+      if (pathname.startsWith("/api/")) {
+        const response = NextResponse.json(
+          { error: "Unauthorized" },
+          { status: 401 },
+        );
+        setCorsHeaders(response.headers, allowedOrigin);
+        return response;
+      }
+      const signInUrl = new URL("/api/auth/signin", request.url);
+      signInUrl.searchParams.set("callbackUrl", request.url);
+      return NextResponse.redirect(signInUrl);
+    }
+  }
+
+  // 3. Pass through with CORS headers
   const response = NextResponse.next();
   setCorsHeaders(response.headers, allowedOrigin);
   return response;
 }
 
 export const config = {
-  matcher: ["/api/:path*"],
+  matcher: ["/api/:path*", "/presentation/:path*"],
 };


### PR DESCRIPTION
## GitHub OAuth Authentication via NextAuth.js (Auth.js v5)

Closes #41

### Changes

**Backend (auth infrastructure):**
- `src/auth.ts` — Auth.js v5 config with GitHub OAuth provider, JWT strategy, session callbacks for username/avatar/ID
- `src/app/api/auth/[...nextauth]/route.ts` — Auth route handler
- `src/middleware.ts` — Auth middleware protecting API and presentation routes, with dev bypass when `AUTH_GITHUB_ID` is not set

**Frontend (sign-in/sign-out UI):**
- `src/app/components/UserMenu.tsx` — Avatar + username + sign-out when authenticated, "Sign in with GitHub" when not, "Dev Mode" badge when OAuth not configured
- `src/app/components/AuthProvider.tsx` — SessionProvider wrapper
- Updated `layout.tsx` to wrap app with AuthProvider and pass `data-auth-enabled`
- Added UserMenu to home page header and presentation page top bar

**Docs:**
- Updated README with Auth.js tech stack entry and OAuth setup instructions
- Decision doc at `.ai-team/decisions/inbox/mcmanus-github-oauth.md`

### Local Dev Still Works
When `AUTH_GITHUB_ID` is not set, all auth middleware is bypassed. The app works exactly as before — no OAuth configuration needed for local development.

### Protected Routes (when OAuth is configured)
- `/api/presentations/*`, `/api/generate/*` → 401 JSON if unauthenticated
- `/presentation/*` → redirect to sign-in

### Public Routes (always accessible)
- `/`, `/auth/signin`, `/api/auth/*`

### Setup (for Shayne)
1. Create a GitHub OAuth App at https://github.com/settings/developers
2. Set callback URL to `http://localhost:3000/api/auth/callback/github`
3. Add `AUTH_GITHUB_ID` and `AUTH_GITHUB_SECRET` to `.env.local`

### Verification
- `npm run build` ✅
- `npx vitest run` — 50 tests pass ✅
- No secrets committed ✅