### PR TITLE
feat: MCP server package for SlideМaker

### DIFF
--- a/.ai-team/decisions/inbox/mcmanus-mcp-server.md
+++ b/.ai-team/decisions/inbox/mcmanus-mcp-server.md
@@ -1,0 +1,111 @@
+# Decision: MCP Server Package for SlideМaker
+
+**Author:** McManus (Backend Dev)
+**Date:** 2025-07-15
+**Status:** Implemented
+**Issue:** #47
+
+## Context
+
+MCP (Model Context Protocol) is a standard for exposing tools to AI assistants like Claude, Copilot CLI, and other MCP-compatible clients. Adding an MCP server lets any MCP client create, list, get, and delete SlideМaker presentations through natural language.
+
+## Decision
+
+Created a standalone npm package at `packages/mcp-server/` that wraps the SlideМaker API as MCP tools using `@modelcontextprotocol/sdk` with stdio transport.
+
+## How It Works
+
+The MCP server is a thin HTTP client — all business logic stays in the Next.js API. Each tool validates input, calls the SlideМaker REST API with Bearer token auth, and returns formatted results.
+
+### Token Resolution Order
+
+1. `SLIDEMAKER_TOKEN` env var
+2. `GITHUB_TOKEN` env var
+3. `gh auth token` CLI output (subprocess, 5s timeout)
+
+If none are found, the server throws a clear error at tool invocation time.
+
+### Configuration
+
+| Env Var | Description | Default |
+|---|---|---|
+| `SLIDEMAKER_API_URL` | Base URL of the SlideМaker app | `http://localhost:3000` |
+| `SLIDEMAKER_TOKEN` | Auth token (highest priority) | — |
+| `GITHUB_TOKEN` | Fallback auth token | — |
+
+## MCP Tools
+
+### `create_presentation`
+- **Input:** `{ topic: string, style?: string, numSlides?: number }`
+- **Calls:** `POST /api/generate` → `POST /api/presentations`
+- **Output:** `{ url, title, slideCount, theme, slides[] }`
+- **Style options:** professional, creative, minimal, technical
+
+### `list_presentations`
+- **Input:** `{}`
+- **Calls:** `GET /api/presentations`
+- **Output:** `{ presentations: [{ title, url, slideCount, updatedAt }] }`
+
+### `get_presentation`
+- **Input:** `{ slug: string }`
+- **Calls:** `GET /api/presentations/{slug}`
+- **Output:** `{ title, theme, slideCount, slides: [{ title, content }], url }`
+
+### `delete_presentation`
+- **Input:** `{ slug: string }`
+- **Calls:** `DELETE /api/presentations/{slug}`
+- **Output:** `{ success: boolean }`
+
+## Running Locally
+
+```bash
+# Build
+cd packages/mcp-server
+npm install
+npm run build
+
+# Run directly
+SLIDEMAKER_API_URL=http://localhost:3000 node dist/index.js
+
+# Or via npm
+npm start
+```
+
+### Claude Desktop config (`claude_desktop_config.json`)
+```json
+{
+  "mcpServers": {
+    "slidemaker": {
+      "command": "node",
+      "args": ["path/to/slidemaker/packages/mcp-server/dist/index.js"],
+      "env": {
+        "SLIDEMAKER_API_URL": "http://localhost:3000"
+      }
+    }
+  }
+}
+```
+
+## Package Structure
+
+```
+packages/mcp-server/
+├── package.json
+├── tsconfig.json
+├── src/
+│   ├── index.ts        # MCP server entry, stdio transport, tool routing
+│   ├── api.ts          # Shared HTTP client for SlideМaker API
+│   └── tools/
+│       ├── create.ts   # create_presentation tool
+│       ├── list.ts     # list_presentations tool
+│       ├── get.ts      # get_presentation tool
+│       └── delete.ts   # delete_presentation tool
+└── dist/               # Compiled output (ES2022, ESNext modules)
+```
+
+## Constraints
+
+- This is a **separate package** — does not modify the main Next.js app
+- The MCP server is a thin client; all business logic lives in the API
+- Uses stdio transport (standard for MCP servers)
+- TypeScript with ES modules targeting ES2022

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@slidemaker/mcp-server",
+  "version": "1.0.0",
+  "description": "MCP server for SlideМaker — expose presentations as tools for Claude, Copilot CLI, and any MCP client",
+  "type": "module",
+  "bin": {
+    "slidemaker-mcp": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "latest"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT"
+}

--- a/packages/mcp-server/src/api.ts
+++ b/packages/mcp-server/src/api.ts
@@ -1,0 +1,36 @@
+export interface RequestOptions {
+  method?: string;
+  body?: unknown;
+}
+
+export async function apiRequest<T>(
+  baseUrl: string,
+  path: string,
+  token: string,
+  options?: RequestOptions
+): Promise<T> {
+  const url = `${baseUrl}${path}`;
+  const method = options?.method ?? "GET";
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  };
+
+  const fetchOptions: RequestInit = { method, headers };
+
+  if (options?.body) {
+    fetchOptions.body = JSON.stringify(options.body);
+  }
+
+  const response = await fetch(url, fetchOptions);
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => "");
+    throw new Error(
+      `SlideМaker API error (${response.status}): ${errorBody || response.statusText}`
+    );
+  }
+
+  return (await response.json()) as T;
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { execSync } from "node:child_process";
+
+import {
+  createPresentationTool,
+  handleCreatePresentation,
+} from "./tools/create.js";
+import {
+  listPresentationsTool,
+  handleListPresentations,
+} from "./tools/list.js";
+import {
+  getPresentationTool,
+  handleGetPresentation,
+} from "./tools/get.js";
+import {
+  deletePresentationTool,
+  handleDeletePresentation,
+} from "./tools/delete.js";
+
+// Resolve auth token: env vars first, then gh CLI
+function resolveToken(): string {
+  if (process.env.SLIDEMAKER_TOKEN) return process.env.SLIDEMAKER_TOKEN;
+  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
+
+  try {
+    const token = execSync("gh auth token", {
+      encoding: "utf-8",
+      timeout: 5000,
+    }).trim();
+    if (token) return token;
+  } catch {
+    // gh CLI not available or not authenticated
+  }
+
+  throw new Error(
+    "No auth token found. Set SLIDEMAKER_TOKEN, GITHUB_TOKEN, or run 'gh auth login'."
+  );
+}
+
+const BASE_URL =
+  process.env.SLIDEMAKER_API_URL ?? "http://localhost:3000";
+
+const server = new Server(
+  { name: "slidemaker", version: "1.0.0" },
+  { capabilities: { tools: {} } }
+);
+
+// List available tools
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    createPresentationTool,
+    listPresentationsTool,
+    getPresentationTool,
+    deletePresentationTool,
+  ],
+}));
+
+// Handle tool calls
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+  const token = resolveToken();
+
+  switch (name) {
+    case "create_presentation":
+      return handleCreatePresentation(
+        args as { topic: string; style?: string; numSlides?: number },
+        BASE_URL,
+        token
+      );
+
+    case "list_presentations":
+      return handleListPresentations(
+        args as Record<string, never>,
+        BASE_URL,
+        token
+      );
+
+    case "get_presentation":
+      return handleGetPresentation(
+        args as { slug: string },
+        BASE_URL,
+        token
+      );
+
+    case "delete_presentation":
+      return handleDeletePresentation(
+        args as { slug: string },
+        BASE_URL,
+        token
+      );
+
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+});
+
+// Start the server
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("SlideМaker MCP server running on stdio");
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/packages/mcp-server/src/tools/create.ts
+++ b/packages/mcp-server/src/tools/create.ts
@@ -1,0 +1,119 @@
+import { apiRequest } from "../api.js";
+
+export const createPresentationTool = {
+  name: "create_presentation",
+  description:
+    "Generate a new presentation with AI. Provide a topic and optionally a style and number of slides.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      topic: {
+        type: "string",
+        description: "The topic or subject for the presentation",
+      },
+      style: {
+        type: "string",
+        enum: ["professional", "creative", "minimal", "technical"],
+        description:
+          "Presentation style (default: professional). Controls tone, layout, and visual design.",
+      },
+      numSlides: {
+        type: "number",
+        description: "Number of slides to generate (1-20, default: 5)",
+      },
+    },
+    required: ["topic"],
+  },
+};
+
+interface CreateInput {
+  topic: string;
+  style?: string;
+  numSlides?: number;
+}
+
+interface GenerateResponse {
+  slides: Array<{ title: string; content: string }>;
+  suggestedTheme?: string;
+}
+
+interface PresentationResponse {
+  id: string;
+  title: string;
+  slides: Array<{ title: string; content: string }>;
+  theme?: string;
+}
+
+export async function handleCreatePresentation(
+  args: CreateInput,
+  baseUrl: string,
+  token: string
+) {
+  if (!args.topic || typeof args.topic !== "string") {
+    throw new Error("topic is required and must be a string");
+  }
+
+  if (
+    args.numSlides !== undefined &&
+    (typeof args.numSlides !== "number" || args.numSlides < 1 || args.numSlides > 20)
+  ) {
+    throw new Error("numSlides must be a number between 1 and 20");
+  }
+
+  if (
+    args.style !== undefined &&
+    !["professional", "creative", "minimal", "technical"].includes(args.style)
+  ) {
+    throw new Error(
+      "style must be one of: professional, creative, minimal, technical"
+    );
+  }
+
+  // Step 1: Generate slides via AI
+  const generateBody: Record<string, unknown> = { topic: args.topic };
+  if (args.style) generateBody.style = args.style;
+  if (args.numSlides) generateBody.numSlides = args.numSlides;
+
+  const generated = await apiRequest<GenerateResponse>(
+    baseUrl,
+    "/api/generate",
+    token,
+    { method: "POST", body: generateBody }
+  );
+
+  // Step 2: Save the presentation
+  const title = args.topic;
+  const presentation = await apiRequest<PresentationResponse>(
+    baseUrl,
+    "/api/presentations",
+    token,
+    {
+      method: "POST",
+      body: {
+        title,
+        slides: generated.slides,
+        theme: generated.suggestedTheme,
+      },
+    }
+  );
+
+  const slug = presentation.id;
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            url: `${baseUrl}/p/${slug}`,
+            title: presentation.title,
+            slideCount: presentation.slides.length,
+            theme: generated.suggestedTheme ?? "black",
+            slides: presentation.slides.map((s) => s.title),
+          },
+          null,
+          2
+        ),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/tools/delete.ts
+++ b/packages/mcp-server/src/tools/delete.ts
@@ -1,0 +1,42 @@
+import { apiRequest } from "../api.js";
+
+export const deletePresentationTool = {
+  name: "delete_presentation",
+  description: "Delete a presentation by its slug.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      slug: {
+        type: "string",
+        description: "The URL slug of the presentation to delete",
+      },
+    },
+    required: ["slug"],
+  },
+};
+
+export async function handleDeletePresentation(
+  args: { slug: string },
+  baseUrl: string,
+  token: string
+) {
+  if (!args.slug || typeof args.slug !== "string") {
+    throw new Error("slug is required and must be a string");
+  }
+
+  await apiRequest<{ message: string }>(
+    baseUrl,
+    `/api/presentations/${encodeURIComponent(args.slug)}`,
+    token,
+    { method: "DELETE" }
+  );
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({ success: true }, null, 2),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/tools/get.ts
+++ b/packages/mcp-server/src/tools/get.ts
@@ -1,0 +1,62 @@
+import { apiRequest } from "../api.js";
+
+export const getPresentationTool = {
+  name: "get_presentation",
+  description:
+    "Get full details of a presentation by its slug, including all slide titles and content.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      slug: {
+        type: "string",
+        description: "The URL slug of the presentation",
+      },
+    },
+    required: ["slug"],
+  },
+};
+
+interface PresentationDetail {
+  id: string;
+  title: string;
+  theme?: string;
+  slides: Array<{ title: string; content: string }>;
+}
+
+export async function handleGetPresentation(
+  args: { slug: string },
+  baseUrl: string,
+  token: string
+) {
+  if (!args.slug || typeof args.slug !== "string") {
+    throw new Error("slug is required and must be a string");
+  }
+
+  const data = await apiRequest<PresentationDetail>(
+    baseUrl,
+    `/api/presentations/${encodeURIComponent(args.slug)}`,
+    token
+  );
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            title: data.title,
+            theme: data.theme ?? "black",
+            slideCount: data.slides.length,
+            slides: data.slides.map((s) => ({
+              title: s.title,
+              content: s.content,
+            })),
+            url: `${baseUrl}/p/${data.id}`,
+          },
+          null,
+          2
+        ),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/tools/list.ts
+++ b/packages/mcp-server/src/tools/list.ts
@@ -1,0 +1,46 @@
+import { apiRequest } from "../api.js";
+
+export const listPresentationsTool = {
+  name: "list_presentations",
+  description:
+    "List all saved presentations. Returns titles, URLs, slide counts, and last-updated timestamps.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {},
+  },
+};
+
+interface PresentationSummary {
+  id: string;
+  title: string;
+  slides: unknown[];
+  updatedAt: string;
+}
+
+export async function handleListPresentations(
+  _args: Record<string, never>,
+  baseUrl: string,
+  token: string
+) {
+  const data = await apiRequest<PresentationSummary[]>(
+    baseUrl,
+    "/api/presentations",
+    token
+  );
+
+  const presentations = data.map((p) => ({
+    title: p.title,
+    url: `${baseUrl}/p/${p.id}`,
+    slideCount: p.slides.length,
+    updatedAt: p.updatedAt,
+  }));
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({ presentations }, null, 2),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

Closes #47

Adds \@slidemaker/mcp-server\ — an MCP (Model Context Protocol) server that exposes SlideМaker as tools for Claude, Copilot CLI, and any MCP-compatible client.

## Package: \packages/mcp-server/\

### MCP Tools
| Tool | Description |
|---|---|
| \create_presentation\ | Generate a new presentation with AI (topic, style, numSlides) |
| \list_presentations\ | List all saved presentations |
| \get_presentation\ | Get full details of a presentation by slug |
| \delete_presentation\ | Delete a presentation by slug |

### Auth Token Resolution
1. \SLIDEMAKER_TOKEN\ env var
2. \GITHUB_TOKEN\ env var
3. \gh auth token\ CLI output

### Config
- \SLIDEMAKER_API_URL\ — Base URL (default: \http://localhost:3000\)

### Build & Run
\\\ash
cd packages/mcp-server
npm install && npm run build
npm start
\\\

The MCP server is a thin HTTP client — all business logic stays in the Next.js API routes.