### PR TITLE
feat: Dockerfile + Azure Container Apps deployment with CI/CD (#43)

### DIFF
--- a/.ai-team/decisions/inbox/mcmanus-containerize.md
+++ b/.ai-team/decisions/inbox/mcmanus-containerize.md
@@ -1,0 +1,54 @@
+### Dockerfile + Azure Container Apps Deployment with CI/CD
+**Author:** McManus (Backend Dev / DevOps) · **Date:** 2026-02-10 · **Issue:** #43
+
+#### Dockerfile Build Strategy
+
+Multi-stage Docker build using `node:22-alpine`:
+1. **deps** — `npm ci` installs production + dev dependencies (needed for build).
+2. **build** — Copies `node_modules` from deps, runs `npm run build`. Next.js `output: "standalone"` produces a self-contained `server.js` with only the required `node_modules` subset (~100MB vs ~500MB full).
+3. **runtime** — Copies only `standalone/`, `.next/static/`, and `public/`. Final image contains no source code, no dev dependencies, no build tooling.
+
+Added `output: "standalone"` to `next.config.ts` — the only source code change. `.dockerignore` excludes `node_modules`, `.next`, `.git`, tests, docs, and env files from build context.
+
+`docker-compose.yml` provided for local dev with `.env.local` injection and `presentations/` volume mount.
+
+#### Azure Resources (Bicep IaC)
+
+`infra/main.bicep` provisions:
+- **Azure Container Registry (ACR)** — Basic SKU, admin disabled, pull via managed identity.
+- **Azure Container App** — Runs the Docker image with HTTP ingress on port 3000, scales 0–3 replicas based on concurrent requests.
+- **Container App Environment + Log Analytics Workspace** — Centralized logging.
+- **Azure Storage Account + blob container** (`presentations`) — For production file persistence.
+- **User-assigned Managed Identity** — Granted ACR Pull and Storage Blob Data Contributor roles.
+
+All resource names use `uniqueString(resourceGroup().id)` to avoid collisions. Parameters: `location` (default: resource group location), `resourcePrefix` (default: `slidemaker`), `containerImage`.
+
+`infra/main.bicepparam` provides sensible defaults (eastus2, slidemaker prefix).
+
+#### CI/CD Pipeline Flow
+
+`.github/workflows/deploy.yml` triggers on push to `master` or manual dispatch:
+
+1. **build-and-push** job:
+   - Checks out code
+   - Azure Login via OIDC (federated credentials, no stored secrets)
+   - Deploys/updates infrastructure via `azure/arm-deploy` with Bicep
+   - Logs into ACR via `az acr login`
+   - Builds Docker image tagged with commit SHA + `latest`
+   - Pushes both tags to ACR
+
+2. **deploy** job (depends on build-and-push):
+   - Azure Login via OIDC
+   - Deploys new image to Container App via `azure/container-apps-deploy-action`
+
+#### Required GitHub Secrets
+
+| Secret | Description | How to set |
+|--------|-------------|------------|
+| `AZURE_CLIENT_ID` | App registration client ID for OIDC | Create in Entra ID → App registrations; add federated credential for `repo:spboyer/slidemaker:ref:refs/heads/master` |
+| `AZURE_TENANT_ID` | Entra ID tenant ID | Found in Entra ID → Overview |
+| `AZURE_SUBSCRIPTION_ID` | Target Azure subscription ID | Found in Azure Portal → Subscriptions |
+
+The app registration's service principal needs **Contributor** on the resource group (`slidemaker-rg`) and **AcrPush** on the container registry. Create the resource group before first deploy: `az group create -n slidemaker-rg -l eastus2`.
+
+No API keys or tokens are stored in the pipeline — OIDC federated credentials provide zero-secret auth to Azure.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+.next
+.git
+.gitignore
+*.md
+screenshots
+playwright-report
+test-results
+coverage
+e2e
+.env*
+.ai-team
+.ai-team-templates

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,71 @@
+name: Build and Deploy to Azure Container Apps
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  RESOURCE_GROUP: slidemaker-rg
+  BICEP_FILE: infra/main.bicep
+  BICEP_PARAMS: infra/main.bicepparam
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+      acr-login-server: ${{ steps.infra.outputs.acrLoginServer }}
+      container-app-name: ${{ steps.infra.outputs.containerAppName }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy Infrastructure
+        id: infra
+        uses: azure/arm-deploy@v2
+        with:
+          resourceGroupName: ${{ env.RESOURCE_GROUP }}
+          template: ${{ env.BICEP_FILE }}
+          parameters: ${{ env.BICEP_PARAMS }}
+
+      - name: ACR Login
+        run: az acr login --name ${{ steps.infra.outputs.acrName }}
+
+      - name: Build and push image
+        id: meta
+        run: |
+          IMAGE="${{ steps.infra.outputs.acrLoginServer }}/slidemaker:${{ github.sha }}"
+          docker build -t $IMAGE -t ${{ steps.infra.outputs.acrLoginServer }}/slidemaker:latest .
+          docker push $IMAGE
+          docker push ${{ steps.infra.outputs.acrLoginServer }}/slidemaker:latest
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    steps:
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy to Container Apps
+        uses: azure/container-apps-deploy-action@v1
+        with:
+          resourceGroup: ${{ env.RESOURCE_GROUP }}
+          containerAppName: ${{ needs.build-and-push.outputs.container-app-name }}
+          imageToDeploy: ${{ needs.build-and-push.outputs.image }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Stage 1: deps
+FROM node:22-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Stage 2: build
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+# Stage 3: runtime
+FROM node:22-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/.next/standalone ./
+COPY --from=build /app/.next/static ./.next/static
+COPY --from=build /app/public ./public
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env.local
+    volumes:
+      - ./presentations:/app/presentations

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,191 @@
+targetScope = 'resourceGroup'
+
+@description('Azure region for all resources')
+param location string = resourceGroup().location
+
+@description('Prefix for all resource names')
+param resourcePrefix string = 'slidemaker'
+
+@description('Container image to deploy (e.g. myacr.azurecr.io/slidemaker:latest)')
+param containerImage string = ''
+
+var uniqueSuffix = uniqueString(resourceGroup().id)
+var acrName = '${replace(resourcePrefix, '-', '')}${uniqueSuffix}'
+var storageName = '${replace(resourcePrefix, '-', '')}${uniqueSuffix}'
+var logAnalyticsName = '${resourcePrefix}-logs-${uniqueSuffix}'
+var envName = '${resourcePrefix}-env-${uniqueSuffix}'
+var appName = '${resourcePrefix}-app'
+var identityName = '${resourcePrefix}-identity'
+var storageContainerName = 'presentations'
+
+// User-assigned Managed Identity
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: identityName
+  location: location
+}
+
+// Azure Container Registry
+resource acr 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+  name: acrName
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  properties: {
+    adminUserEnabled: false
+  }
+}
+
+// ACR Pull role assignment for managed identity
+resource acrPullRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, managedIdentity.id, '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+  scope: acr
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Storage Account
+resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageName
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    accessTier: 'Hot'
+    allowBlobPublicAccess: false
+    minimumTlsVersion: 'TLS1_2'
+  }
+}
+
+// Blob container for presentations
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+  parent: storage
+  name: 'default'
+}
+
+resource presentationsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01' = {
+  parent: blobService
+  name: storageContainerName
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+// Storage Blob Data Contributor role for managed identity
+resource storageBlobRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storage.id, managedIdentity.id, 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
+  scope: storage
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Log Analytics Workspace
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: logAnalyticsName
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+// Container App Environment
+resource containerAppEnv 'Microsoft.App/managedEnvironments@2023-05-01' = {
+  name: envName
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalytics.properties.customerId
+        sharedKey: logAnalytics.listKeys().primarySharedKey
+      }
+    }
+  }
+}
+
+// Container App
+resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {
+  name: appName
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${managedIdentity.id}': {}
+    }
+  }
+  properties: {
+    managedEnvironmentId: containerAppEnv.id
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 3000
+        transport: 'http'
+      }
+      registries: [
+        {
+          server: acr.properties.loginServer
+          identity: managedIdentity.id
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'slidemaker'
+          image: !empty(containerImage) ? containerImage : 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          env: [
+            {
+              name: 'NODE_ENV'
+              value: 'production'
+            }
+            {
+              name: 'AZURE_STORAGE_ACCOUNT_NAME'
+              value: storage.name
+            }
+            {
+              name: 'AZURE_STORAGE_CONTAINER_NAME'
+              value: storageContainerName
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 0
+        maxReplicas: 3
+        rules: [
+          {
+            name: 'http-rule'
+            http: {
+              metadata: {
+                concurrentRequests: '50'
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+output acrLoginServer string = acr.properties.loginServer
+output acrName string = acr.name
+output containerAppFqdn string = containerApp.properties.configuration.ingress.fqdn
+output containerAppName string = containerApp.name
+output storageAccountName string = storage.name
+output managedIdentityClientId string = managedIdentity.properties.clientId
+output containerAppEnvName string = containerAppEnv.name

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -1,0 +1,5 @@
+using './main.bicep'
+
+param location = 'eastus2'
+param resourcePrefix = 'slidemaker'
+param containerImage = ''

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Adds containerization and Azure deployment infrastructure for SlideМaker.

### Changes
- **Dockerfile**: Multi-stage build (deps → build → runtime) using \
ode:22-alpine\ with Next.js standalone output
- **docker-compose.yml**: Local dev with \.env.local\ injection and \presentations/\ volume
- **infra/main.bicep**: Azure Container Registry, Container App, Storage Account, Log Analytics, Managed Identity with RBAC
- **infra/main.bicepparam**: Default parameters (eastus2, slidemaker prefix)
- **.github/workflows/deploy.yml**: CI/CD pipeline with OIDC auth, ACR build+push, Container Apps deploy
- **next.config.ts**: Added \output: 'standalone'\ for Docker-optimized builds
- **.dockerignore**: Excludes dev artifacts from build context

### Required GitHub Secrets
- \AZURE_CLIENT_ID\ — OIDC app registration client ID
- \AZURE_TENANT_ID\ — Entra ID tenant ID
- \AZURE_SUBSCRIPTION_ID\ — Target subscription ID

### Testing
- \
pm run build\ — standalone output verified (\.next/standalone/server.js\ created)
- \
pm run test\ — 60 passed, 5 skipped (no regressions)

Closes #43